### PR TITLE
Allow passing in a custom `:start` in trace/span `opts`

### DIFF
--- a/lib/spandex.ex
+++ b/lib/spandex.ex
@@ -546,7 +546,7 @@ defmodule Spandex do
     |> Keyword.put_new(:name, name)
     |> Keyword.put(:trace_id, span_context.trace_id)
     |> Keyword.put(:parent_id, span_context.parent_id)
-    |> Keyword.put(:start, adapter.now())
+    |> Keyword.put_new(:start, adapter.now())
     |> Keyword.put(:id, adapter.span_id())
     |> Span.new()
   end

--- a/test/spandex_test.exs
+++ b/test/spandex_test.exs
@@ -72,6 +72,16 @@ defmodule Spandex.Test.SpandexTest do
       assert String.contains?(log, "trace_id")
       assert String.contains?(log, "span_id")
     end
+
+    test "retains :start if passed in opts" do
+      start = System.monotonic_time()
+      completion_time = start + 1_234
+      opts = @base_opts ++ @span_opts ++ [start: start, completion_time: completion_time]
+      assert {:ok, %Trace{}} = Spandex.start_trace("root_span", opts)
+
+      assert %Span{name: "root_span", start: ^start, completion_time: ^completion_time} =
+               Spandex.current_span(@base_opts)
+    end
   end
 
   describe "Spandex.start_span/2" do


### PR DESCRIPTION
This is helpful for "retroactive" traces/spans, where we get a completion event with a duration, and we can use that duration to calculate the start time.